### PR TITLE
Harden XStream deserialization in vulnerable components lesson

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/vulnerablecomponents/VulnerableComponentsLesson.java
+++ b/src/main/java/org/owasp/webgoat/lessons/vulnerablecomponents/VulnerableComponentsLesson.java
@@ -23,6 +23,7 @@
 package org.owasp.webgoat.lessons.vulnerablecomponents;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.NoTypePermission;
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AssignmentHints;
@@ -41,6 +42,8 @@ public class VulnerableComponentsLesson extends AssignmentEndpoint {
     XStream xstream = new XStream();
     xstream.setClassLoader(Contact.class.getClassLoader());
     xstream.alias("contact", ContactImpl.class);
+    xstream.addPermission(NoTypePermission.NONE);
+    xstream.allowTypes(new Class[] {ContactImpl.class});
     xstream.ignoreUnknownElements();
     Contact contact = null;
 


### PR DESCRIPTION
### Motivation
- The `/VulnerableComponents/attack1` endpoint deserialized attacker-controlled XML via XStream without any type allowlist, enabling dynamic-proxy/gadget payloads to be instantiated and resulting in an RCE-capable sink; this change restricts deserialization to the intended DTO to remove the attack surface.

### Description
- Added import of `NoTypePermission` and configured XStream in `VulnerableComponentsLesson` to `addPermission(NoTypePermission.NONE)` and `allowTypes(new Class[] {ContactImpl.class})` so only `ContactImpl` may be deserialized, preserving lesson behavior while blocking proxy/gadget payloads.

### Testing
- Attempted `./mvnw -q -DskipTests -pl . -am compile` which failed due to environment proxy blocking the Maven wrapper download (HTTP 403).
- Attempted `mvn -q -DskipTests compile` which failed due to environment proxy blocking dependency resolution from Maven Central (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afa27437d8832b813e3bd4cb4d2e1f)